### PR TITLE
Feature/add twitter link

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -11,6 +11,11 @@
       </a>
     </li>
     <li>
+      <a href="https://x.com/KeM198_tw">
+        <i class="fa-brands fa-twitter"></i>
+      </a>
+    </li>
+    <li>
       <a href="https://misskey.io/@KeM198">
         <i class="fa-solid fa-paw"></i>
       </a>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -6,11 +6,6 @@
       </a>
     </li>
     <li>
-      <a href="https://www.pixiv.net/users/7791923">
-        <i class="fa-solid fa-palette"></i>
-      </a>
-    </li>
-    <li>
       <a href="https://x.com/KeM198_tw">
         <i class="fa-brands fa-twitter"></i>
       </a>
@@ -18,6 +13,11 @@
     <li>
       <a href="https://misskey.io/@KeM198">
         <i class="fa-solid fa-paw"></i>
+      </a>
+    </li>
+    <li>
+      <a href="https://www.pixiv.net/users/7791923">
+        <i class="fa-solid fa-palette"></i>
       </a>
     </li>
     <li>


### PR DESCRIPTION
This pull request updates the social links in the website footer to improve accuracy and order. The most important changes include updating the Twitter link and icon, and reordering the Pixiv link.

Social link updates:

* Changed the Twitter link from `pixiv.net/users/7791923` to `x.com/KeM198_tw`, and updated the icon from a palette (`fa-palette`) to the Twitter logo (`fa-twitter`).
* Moved the Pixiv link to a new list item after the Twitter link to maintain proper ordering of social links.