### PR TITLE
small changed

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -26,7 +26,7 @@
       </a>
     </li>
   </ul>
-  <p class="footer-copy">&copy; 2022 kenkenpa198 / KeM198</p>
+  <p class="footer-copy">&copy; 2022 KeM198</p>
   <div class="footer-jump">
     <a href="#">
       <p>


### PR DESCRIPTION
This pull request updates the copyright notice in the website footer.

* Changed the footer text in `docs/_includes/footer.html` to display "&copy; 2022 KeM198" instead of "&copy; 2022 kenkenpa198 / KeM198" for a more streamlined and consistent attribution.