### PR TITLE
Update references to GitHub username and links across multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ HTTPS での公開は GitHub Pages の `Enforce HTTPS` 設定を使用してい�
 
 より詳しい再現手順やビルド方法は次のリポジトリを参照すること。
 
-- [kenkenpa198/helloworld-github-pages-with-jekyll](https://github.com/kem198/helloworld-github-pages-with-jekyll)
+- [kem198/helloworld-github-pages-with-jekyll](https://github.com/kem198/helloworld-github-pages-with-jekyll)
 
 ## 3. 作業方法メモ
 
@@ -215,8 +215,8 @@ HTTPS での公開は GitHub Pages の `Enforce HTTPS` 設定を使用してい�
 
 下記を参考に環境構築を行う。
 
-- (~ v1.3.0) [kenkenpa198/tutorial-jekyll](https://github.com/kem198/tutorial-jekyll) > `2. 環境構築メモ`
-- (v2.0.0 ~) [kenkenpa198/helloworld-github-pages-with-jekyll](https://github.com/kem198/helloworld-github-pages-with-jekyll)
+- (~ v1.3.0) [kem198/tutorial-jekyll](https://github.com/kem198/tutorial-jekyll) > `2. 環境構築メモ`
+- (v2.0.0 ~) [kem198/helloworld-github-pages-with-jekyll](https://github.com/kem198/helloworld-github-pages-with-jekyll)
 
 ### 3.2. ビルド・Web サーバの立ち上げ・表示
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@ title: KeM's Clew
 #   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
-github_username: kenkenpa198
+github_username: kem198
 
 # Build settings
 theme: minima
@@ -79,8 +79,7 @@ permalink: notes/:year-:month-:day-:title:output_ext
 
 # defaults
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
       type: "posts"
     values:

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="site-footer h-card">
   <ul class="footer-sns">
     <li>
-      <a href="https://github.com/kenkenpa198">
+      <a href="https://github.com/kem198">
         <i class="fa-brands fa-github"></i>
       </a>
     </li>

--- a/docs/_posts/2022-11-18-hello-world.md
+++ b/docs/_posts/2022-11-18-hello-world.md
@@ -13,4 +13,4 @@ type: post
 [Jekyll](http://jekyllrb-ja.github.io/) × [GitHub Pages](https://docs.github.com/ja/pages) でブログ機能を仮実装しました！  
 けっこういい感じ。
 
-チュートリアル内容などは [kenkenpa198/tutorial-jekyll](https://github.com/kenkenpa198/tutorial-jekyll) へ残しているのでよかったらどぞー。
+チュートリアル内容などは [kem198/tutorial-jekyll](https://github.com/kem198/tutorial-jekyll) へ残しているのでよかったらどぞー。

--- a/docs/_posts/2022-11-18-test-markdown.md
+++ b/docs/_posts/2022-11-18-test-markdown.md
@@ -90,15 +90,11 @@ description: マークダウンのテスト用ページです。
 
 *イタリック（アスタリスク1個）*
 
-_イタリック（アンダースコア1個）_
-
 __ボールド（アンダースコア2個）__
-
-**ボールド（アスタリスク2個）**
 
 ~~取り消し線（チルダ2個）~~
 
-~~***組み合わせ***~~
+~~*__組み合わせ__*~~
 
 ## 5. リンク
 
@@ -292,7 +288,7 @@ abcdefABCDEF
 ```shell
 # shell
 $ cd
-$ git clone https://github.com/kenkenpa198/dotfiles.git
+$ git clone https://github.com/kem198/dotfiles.git
 $ source ~/dotfiles/.setup/Linux/setup.sh
 ```
 

--- a/docs/_posts/2022-11-23-published-homepage.md
+++ b/docs/_posts/2022-11-23-published-homepage.md
@@ -11,7 +11,7 @@ lastmod: 2023-01-06 22:44:02
 
 諸々落ち着いたため本日が正式リリース日ということで😌
 
-実装内容に関しては [kenkenpa198/kems-clew.net](https://github.com/kenkenpa198/kems-clew.net) へまとめています。  
+実装内容に関しては [kem198/kems-clew.net](https://github.com/kem198/kems-clew.net) へまとめています。  
 免責事項などは [こちら](./about/) をご覧ください。
 
 [Notes](/notes.html) ページとか現状超見づらいので、もうしばらくは調整が続きそう。

--- a/docs/_posts/2022-11-24-sql-made-by-me.md
+++ b/docs/_posts/2022-11-24-sql-made-by-me.md
@@ -11,7 +11,7 @@ lastmod: 2023-12-10
 
 自作の SQL や便利な構文をまとめているページ。SQL Server 向け。
 
-[標準 SQL 集]({% post_url 2022-11-24-sql-standard %}) と同じく [kenkenpa198/mssql-with-docker](https://github.com/kenkenpa198/mssql-with-docker) からの引っ越しページ。
+[標準 SQL 集]({% post_url 2022-11-24-sql-standard %}) と同じく [kem198/mssql-with-docker](https://github.com/kem198/mssql-with-docker) からの引っ越しページ。
 
 <!-- omit in toc -->
 ## リンク

--- a/docs/_posts/2022-11-24-sql-standard.md
+++ b/docs/_posts/2022-11-24-sql-standard.md
@@ -12,7 +12,7 @@ lastmod: 2023-01-06 22:44:13
 SQL Server にて扱える標準 SQL を中心にまとめた自分用メモ。  
 他の RDBMS 向けの内容も一部混在しているため注意。
 
-[kenkenpa198/mssql-with-docker](https://github.com/kenkenpa198/mssql-with-docker) にて管理していたファイルを当サイト上へ引っ越したもの。
+[kem198/mssql-with-docker](https://github.com/kem198/mssql-with-docker) にて管理していたファイルを当サイト上へ引っ越したもの。
 
 <!-- omit in toc -->
 ## リンク

--- a/docs/_posts/2024-01-13-my-snippets.md
+++ b/docs/_posts/2024-01-13-my-snippets.md
@@ -15,7 +15,7 @@ tags:
   - windows
   - vscode
 date: 2024-01-13
-lastmod: 2024-08-19
+lastmod: 2025-10-13
 ---
 
 自分用便利スニペット集。
@@ -33,7 +33,7 @@ lastmod: 2024-08-19
   // コード
   ```
 
-  - 参考文献・出典
+    - 参考文献・出典
 
 ## 1. 記号
 
@@ -73,7 +73,7 @@ lastmod: 2024-08-19
   \n|\r\n|\r
   ```
 
-  - [正規表現：改行コードの表現方法。置換による削除 \| WWWクリエイターズ](https://www-creators.com/archives/2551)
+    - [正規表現：改行コードの表現方法。置換による削除 \| WWWクリエイターズ](https://www-creators.com/archives/2551)
 
 ### 2.3. URL
 
@@ -89,8 +89,8 @@ lastmod: 2024-08-19
   (http|https):\/\/[-\w\.]+(:\d+)?(\/[^\s]*)?
   ```
 
-  - [とほほの正規表現入門 - とほほのWWW入門](https://www.tohoho-web.com/ex/regexp.html)
-  - [正規表現 - とほほのWWW入門](https://www.tohoho-web.com/perl/regexp.htm)
+    - [とほほの正規表現入門 - とほほのWWW入門](https://www.tohoho-web.com/ex/regexp.html)
+    - [正規表現 - とほほのWWW入門](https://www.tohoho-web.com/perl/regexp.htm)
 
 ### 2.4. その他
 
@@ -111,8 +111,8 @@ lastmod: 2024-08-19
   ^^^^^
   ```
 
-  - [正規表現構文早見表 - JavaScript \| MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E3%82%A2%E3%82%B5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3)
-  - [正規表現のマッチングをどこからでも―「境界アサーション」と「ルックアラウンドアサーション」：ECMAScriptで学ぶ正規表現（7） - ＠IT](https://atmarkit.itmedia.co.jp/ait/articles/2207/15/news002.html)
+    - [正規表現構文早見表 - JavaScript \| MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E3%82%A2%E3%82%B5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3)
+    - [正規表現のマッチングをどこからでも―「境界アサーション」と「ルックアラウンドアサーション」：ECMAScriptで学ぶ正規表現（7） - ＠IT](https://atmarkit.itmedia.co.jp/ait/articles/2207/15/news002.html)
 
 - 金額をカンマ区切りへ変換
 
@@ -134,7 +134,7 @@ lastmod: 2024-08-19
   1,234,567,890,123
   ```
 
-  - [正規表現のマッチングをどこからでも―「境界アサーション」と「ルックアラウンドアサーション」：ECMAScriptで学ぶ正規表現（7） - ＠IT](https://atmarkit.itmedia.co.jp/ait/articles/2207/15/news002.html)
+    - [正規表現のマッチングをどこからでも―「境界アサーション」と「ルックアラウンドアサーション」：ECMAScriptで学ぶ正規表現（7） - ＠IT](https://atmarkit.itmedia.co.jp/ait/articles/2207/15/news002.html)
 
 ## 3. Linux
 
@@ -191,8 +191,8 @@ lastmod: 2024-08-19
   Codename:       jammy
   ```
 
-  - [lsb_release – ディストリビューションのバージョン情報の確認 \| Linuxコマンド.NET](https://linuxcommand.net/lsb_release/)
-  - [Windows11 + WSL で Ubuntu 環境を構築するずんだもん - YouTube](https://www.youtube.com/watch?v=odDJ3QvlF2g)
+    - [lsb_release – ディストリビューションのバージョン情報の確認 \| Linuxコマンド.NET](https://linuxcommand.net/lsb_release/)
+    - [Windows11 + WSL で Ubuntu 環境を構築するずんだもん - YouTube](https://www.youtube.com/watch?v=odDJ3QvlF2g)
 
 - `neofetch` コマンドで確認する
 
@@ -211,7 +211,7 @@ lastmod: 2024-08-19
 
 ### 3.2. alias
 
-- alias 一覧 ([kenkenpa198/dotfiles > alias.zsh](https://github.com/kenkenpa198/dotfiles/blob/main/zsh/rc/alias.zsh))
+- alias 一覧 ([kem198/dotfiles > alias.zsh](https://github.com/kem198/dotfiles/blob/main/zsh/rc/alias.zsh))
 
   ```shell
   alias
@@ -259,7 +259,7 @@ lastmod: 2024-08-19
   sudo apt-get autoclean -y
   ```
 
-  - [Ubuntu 20.04 LTS を 22.04 LTS にアップグレードする - Uzabase for Engineers](https://tech.uzabase.com/entry/2022/10/05/163458)
+    - [Ubuntu 20.04 LTS を 22.04 LTS にアップグレードする - Uzabase for Engineers](https://tech.uzabase.com/entry/2022/10/05/163458)
 
 ### 3.4. chown
 
@@ -269,9 +269,9 @@ lastmod: 2024-08-19
   sudo chown -R $USER:$USER .
   ```
 
-  - [man chown (1): ファイルの所有者とグループを変更する](https://ja.manpages.org/chown)
-  - [WSL2でDockerを使用する際の権限問題を解決するシンプルな方法（docker-compose.yml使用） #Docker - Qiita](https://qiita.com/twu_go/items/a449e3006bd74fc7d10d)
-  - [Linuxのユーザーとグループって何だろう？：“応用力”をつけるためのLinux再入門（10）（1/2 ページ） - ＠IT](https://atmarkit.itmedia.co.jp/ait/articles/1706/02/news014.html)
+    - [man chown (1): ファイルの所有者とグループを変更する](https://ja.manpages.org/chown)
+    - [WSL2でDockerを使用する際の権限問題を解決するシンプルな方法（docker-compose.yml使用） #Docker - Qiita](https://qiita.com/twu_go/items/a449e3006bd74fc7d10d)
+    - [Linuxのユーザーとグループって何だろう？：“応用力”をつけるためのLinux再入門（10）（1/2 ページ） - ＠IT](https://atmarkit.itmedia.co.jp/ait/articles/1706/02/news014.html)
 
 ### 3.5. curl
 
@@ -361,7 +361,7 @@ lastmod: 2024-08-19
   # ...
   ```
 
-  - [man grep (1): パターンにマッチする行を表示する](https://ja.manpages.org/grep#)
+    - [man grep (1): パターンにマッチする行を表示する](https://ja.manpages.org/grep#)
 
 ### 3.7. seq
 
@@ -379,7 +379,7 @@ lastmod: 2024-08-19
 
 ### 3.8. split
 
-  - CSV ファイルを 100 行単位で分割する
+- CSV ファイルを 100 行単位で分割する
 
     ```shell
     mkdir -p split && \
@@ -412,7 +412,7 @@ lastmod: 2024-08-19
   SystemDirectory : C:\WINDOWS\system32
   Organization    :
   BuildNumber     : 22631
-  RegisteredUser  : kenkenpa198
+  RegisteredUser  : kem198
   SerialNumber    : *****-*****-*****-*****
   Version         : 10.0.22631
   ```
@@ -470,7 +470,7 @@ lastmod: 2024-08-19
   OS バージョン:          10.0.22631 N/A ビルド 22631
   ```
 
-  - [PowerShellシステム要件、バージョン情報メモ \#Windows10 - Qiita](https://qiita.com/e4rfx/items/e370ba343a3c3841b646)
+    - [PowerShellシステム要件、バージョン情報メモ \#Windows10 - Qiita](https://qiita.com/e4rfx/items/e370ba343a3c3841b646)
 
 - cmd の ver コマンドを利用する
 
@@ -485,7 +485,7 @@ lastmod: 2024-08-19
   Microsoft Windows [Version 10.0.22631.3527]
   ```
 
-  - [Windows のバージョンを表示する \| Operations Lab.](https://operationslab.wordpress.com/2013/03/10/windows-のバージョンを表示する/)
+    - [Windows のバージョンを表示する \| Operations Lab.](https://operationslab.wordpress.com/2013/03/10/windows-のバージョンを表示する/)
 
 ### 4.3. WSL
 
@@ -526,20 +526,20 @@ lastmod: 2024-08-19
 ## 5. Git
 
 - ⚠️: 対象コミットの歴史を改変する操作。
-  - **リモートブランチへプッシュ済みの場合、無断で行わないこと** 。
+    - **リモートブランチへプッシュ済みの場合、無断で行わないこと** 。
 
 ### 5.1. remote
 
 - リモートリポジトリを登録する
 
   ```shell
-  git remote add origin https://github.com/kenkenpa198/dotfiles
+  git remote add origin https://github.com/kem198/dotfiles
   ```
 
 - リモートリポジトリの URL を変更する
 
   ```shell
-  git remote set-url origin git@github.com:kenkenpa198/dotfiles.git
+  git remote set-url origin git@github.com:kem198/dotfiles.git
   ```
 
 - リモートリポジトリの確認
@@ -551,8 +551,8 @@ lastmod: 2024-08-19
   ```shell
   # e.g.
   $ git remote -v
-  origin  git@github.com:kenkenpa198/dotfiles.git (fetch)
-  origin  git@github.com:kenkenpa198/dotfiles.git (push)
+  origin  git@github.com:kem198/dotfiles.git (fetch)
+  origin  git@github.com:kem198/dotfiles.git (push)
   ```
 
 ### 5.2. ⚠️Git の操作を取り消す
@@ -588,8 +588,8 @@ $ git reset --soft HEAD@{1}
 
 ```shell
 $ gll
-* dc80a8f 2024-01-13 11:33:09 (HEAD -> main) wip by"kenkenpa198"                   # (1)
-* 07e84cc 2024-01-13 11:27:11 [add]add note 2024-01-13-my-snippets by"kenkenpa198" # (2)
+* dc80a8f 2024-01-13 11:33:09 (HEAD -> main) wip by"kem198"                   # (1)
+* 07e84cc 2024-01-13 11:27:11 [add]add note 2024-01-13-my-snippets by"kem198" # (2)
 ```
 
 ```shell
@@ -620,7 +620,7 @@ Successfully rebased and updated refs/heads/main. # 返った結果
 
 # 4. コミットログとファイル内容を確認する
 $ gll
-* 8ed7b8a 2024-01-13 10:57:20 (HEAD -> main) [add]add note 2024-01-13-my-snippets by"kenkenpa198"
+* 8ed7b8a 2024-01-13 10:57:20 (HEAD -> main) [add]add note 2024-01-13-my-snippets by"kem198"
 ...
 ```
 
@@ -628,11 +628,11 @@ $ gll
 
 - [5. rebase -i でコミットをまとめる｜サル先生のGit入門【プロジェクト管理ツールBacklog】](https://backlog.com/ja/git-tutorial/stepup/32/)
 
-※ 実行しているコマンド `$ gll` は [git log のエイリアス](https://github.com/kenkenpa198/dotfiles/blob/fe695c145ec1c6b35849622cc3b26703d0ef5700/zsh/rc/alias.zsh#L100) 。
+※ 実行しているコマンド `$ gll` は [git log のエイリアス](https://github.com/kem198/dotfiles/blob/fe695c145ec1c6b35849622cc3b26703d0ef5700/zsh/rc/alias.zsh#L100) 。
 
 ### 5.4. キャッシュを削除する
 
-[kenkenpa198/dotfiles](https://github.com/kenkenpa198/dotfiles?tab=readme-ov-file#git-%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5%E5%89%8A%E9%99%A4%E6%89%8B%E9%A0%86) にも記載しているもの。
+[kem198/dotfiles](https://github.com/kem198/dotfiles?tab=readme-ov-file#git-%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5%E5%89%8A%E9%99%A4%E6%89%8B%E9%A0%86) にも記載しているもの。
 
 - グローバルな除外設定 (`.gitignore_global` など) を設定する前にコミットをしてしまった。
 - 過去に追跡対象としてコミットしたファイルを `.gitignore` の追跡対象外へ追加する。
@@ -661,8 +661,8 @@ git commit -m 'commit comments'
 
 - [.gitignoreに記載したのに反映されない件 #Git - Qiita](https://qiita.com/fuwamaki/items/3ed021163e50beab7154)
 - [Git - git-rm Documentation](https://git-scm.com/docs/git-rm)
-  - [-r](https://git-scm.com/docs/git-rm#Documentation/git-rm.txt--r)
-  - [--cached](https://git-scm.com/docs/git-rm#Documentation/git-rm.txt---cached)
+    - [-r](https://git-scm.com/docs/git-rm#Documentation/git-rm.txt--r)
+    - [--cached](https://git-scm.com/docs/git-rm#Documentation/git-rm.txt---cached)
 - [git-rm – Git コマンドリファレンス（日本語版）](https://tracpath.com/docs/git-rm/)
 
 ## 6. Docker
@@ -974,7 +974,7 @@ Docker version 25.0.2, build 29cf629
   docker image prune -f
   ```
 
-  - [docker imagesに表示される＜none＞を消す。dangling \| codechord](https://codechord.com/2019/08/docker-images-none-dangling/)
+    - [docker imagesに表示される＜none＞を消す。dangling \| codechord](https://codechord.com/2019/08/docker-images-none-dangling/)
 
 ### 6.4. Volume
 
@@ -1030,7 +1030,7 @@ Composer version 2.6.6 2023-12-08 18:32:26
   composer install
   ```
 
-  - [Command-line interface / Commands - Composer](https://getcomposer.org/doc/03-cli.md#install-i)
+    - [Command-line interface / Commands - Composer](https://getcomposer.org/doc/03-cli.md#install-i)
 
 - オートローダーを更新する
 
@@ -1038,7 +1038,7 @@ Composer version 2.6.6 2023-12-08 18:32:26
   composer dump-autoload
   ```
 
-  - [Command-line interface / Commands - Composer](https://getcomposer.org/doc/03-cli.md#dump-autoload-dumpautoload)
+    - [Command-line interface / Commands - Composer](https://getcomposer.org/doc/03-cli.md#dump-autoload-dumpautoload)
 
 ### 7.2. Artisan
 
@@ -1080,7 +1080,7 @@ Composer version 2.6.6 2023-12-08 18:32:26
   php artisan key:generate
   ```
 
-  - [暗号化 10.x Laravel](https://readouble.com/laravel/10.x/ja/encryption.html)
+    - [暗号化 10.x Laravel](https://readouble.com/laravel/10.x/ja/encryption.html)
 
 #### 7.2.3. make
 
@@ -1205,7 +1205,7 @@ Composer version 2.6.6 2023-12-08 18:32:26
 - テーブルをすべて削除してからマイグレーションを実行する
 
   ```shell
-  $ php artisan migrate:fresh
+  php artisan migrate:fresh
   ```
 
   ```shell
@@ -1327,7 +1327,7 @@ Composer version 2.6.6 2023-12-08 18:32:26
 }
 ```
 
-これを `ワークスペース/.vscode/settings.json` へ記述すると、[ユーザー設定で行われている](https://github.com/kenkenpa198/dotfiles/blob/0defd6780a2505a590646184708781cf54fd9553/config/Code/User/settings.json#L22-L24) 下記の記述を無効化できる。
+これを `ワークスペース/.vscode/settings.json` へ記述すると、[ユーザー設定で行われている](https://github.com/kem198/dotfiles/blob/0defd6780a2505a590646184708781cf54fd9553/config/Code/User/settings.json#L22-L24) 下記の記述を無効化できる。
 
 - 保存時に新規行を挿入 (`files.insertFinalNewline`)
 - 保存時に不要行を除去 (`files.trimFinalNewlines`)
@@ -1361,7 +1361,7 @@ Composer version 2.6.6 2023-12-08 18:32:26
   =IFERROR(MAX(INDIRECT(ADDRESS(ROW(),1)):INDIRECT(ADDRESS(ROW(),COLUMN()-1)))+1,1)
   ```
 
-  - [Excel ドキュメントを書く時の定石集 - Neo's World](https://neos21.net/tech/business-communication/excel-best-practices.html)
+    - [Excel ドキュメントを書く時の定石集 - Neo's World](https://neos21.net/tech/business-communication/excel-best-practices.html)
 
 - 🔄 縦に連番を振る (数値以外のセルでリセット)
 
@@ -1381,7 +1381,7 @@ Composer version 2.6.6 2023-12-08 18:32:26
   =MID(CELL("filename",A1),FIND("]",CELL("filename",A1))+1,99)
   ```
 
-  - [Excelの表でシート名を利用するのに毎度手動でコピペする修行は不要！ 関数で取得する方法 - 残業を減らす！Officeテクニック - 窓の杜](https://forest.watch.impress.co.jp/docs/serial/offitech/1453353.html)
+    - [Excelの表でシート名を利用するのに毎度手動でコピペする修行は不要！ 関数で取得する方法 - 残業を減らす！Officeテクニック - 窓の杜](https://forest.watch.impress.co.jp/docs/serial/offitech/1453353.html)
 
 ## 11. その他
 
@@ -1401,8 +1401,8 @@ Composer version 2.6.6 2023-12-08 18:32:26
   username@example.com
   ```
 
-  - [example.com](https://example.com/)
-  - [example.com - Wikipedia](https://ja.wikipedia.org/wiki/Example.com)
+    - [example.com](https://example.com/)
+    - [example.com - Wikipedia](https://ja.wikipedia.org/wiki/Example.com)
 
 ### 11.2. Google 検索
 
@@ -1416,4 +1416,4 @@ Composer version 2.6.6 2023-12-08 18:32:26
   site:https://www.example.com/ramen つけ麺
   ```
 
-  - [検索演算子「site: 」の使い方 \| Google 検索セントラル  \|  ドキュメント  \|  Google for Developers](https://developers.google.com/search/docs/monitor-debug/search-operators/all-search-site?hl=ja)
+    - [検索演算子「site: 」の使い方 \| Google 検索セントラル  \|  ドキュメント  \|  Google for Developers](https://developers.google.com/search/docs/monitor-debug/search-operators/all-search-site?hl=ja)

--- a/docs/_posts/2024-03-02-updated-kems-clew-v2.md
+++ b/docs/_posts/2024-03-02-updated-kems-clew-v2.md
@@ -14,7 +14,7 @@ lastmod: 2024-03-02
 
 表題のとおり、KeM's Clew をアップグレードしました。v2 系としています。
 
-- [Release v2.0.0 · kenkenpa198/kems-clew.net](https://github.com/kenkenpa198/kems-clew.net/releases/tag/v2.0.0)
+- [Release v2.0.0 · kem198/kems-clew.net](https://github.com/kem198/kems-clew.net/releases/tag/v2.0.0)
 
 経緯と更新内容について紹介します！
 
@@ -40,7 +40,7 @@ lastmod: 2024-03-02
 具体的な技術情報は次の内容をご参考ください。
 
 - [About > 使用している技術・素材](https://clew.kem198.net/about/#使用している技術素材)
-- [kenkenpa198/kems-clew.net > 2.3. (v2.0.0 ～) minima テーマへ切り替え](https://github.com/kenkenpa198/kems-clew.net?tab=readme-ov-file#23-v200--minima-%E3%83%86%E3%83%BC%E3%83%9E%E3%81%B8%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88)
+- [kem198/kems-clew.net > 2.3. (v2.0.0 ～) minima テーマへ切り替え](https://github.com/kem198/kems-clew.net?tab=readme-ov-file#23-v200--minima-%E3%83%86%E3%83%BC%E3%83%9E%E3%81%B8%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88)
 
 Jekyll の Liquid 構文や Sass など、改めて触れる機会になってよかった。
 
@@ -118,7 +118,7 @@ Jekyll の Liquid 構文や Sass など、改めて触れる機会になって�
 
 例えばよくあるブログサービスだと「次の記事へ」ボタンは【**過去の日付**】の記事へ遷移することが多いと思うけれど、`page.next` は【**未来の日付**】の記事情報が格納されている。このため「次の記事へ」に `page.next` を当ててしまうと、(イメージでの) 前のページへ遷移してしまう……。
 
-これに対して自分の実装上では [単純に逆にして当てはめています](https://github.com/kenkenpa198/kems-clew.net/blob/main/docs/_includes/nav-pager.html) 。「Next (次の記事へ)」と表示されているリンク先は、実は `page.previous` が設定されている、という感じ。
+これに対して自分の実装上では [単純に逆にして当てはめています](https://github.com/kem198/kems-clew.net/blob/main/docs/_includes/nav-pager.html) 。「Next (次の記事へ)」と表示されているリンク先は、実は `page.previous` が設定されている、という感じ。
 
 記事の順番をコード内で制御すればもっとわかりやすくできるはず……その内改善しておきたい。
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -6,12 +6,12 @@ permalink: /about/
 
 ## このサイトは何？
 
-[KeM's Clew](https://clew.kem198.net/) (以下「当サイト」) は、管理人である kenkenpa198 (または KeM198) が趣味で制作・公開しているウェブサイトです。
+[KeM's Clew](https://clew.kem198.net/) (以下「当サイト」) は、管理人である KeM198 が趣味で制作・公開しているウェブサイトです。
 
 当サイトの構築情報は下記にて公開しています。
 
-- [kenkenpa198/kems-clew.net](https://github.com/kenkenpa198/kems-clew.net): 当サイトのソースコード
-- [kenkenpa198/modane-live2d-widget](https://github.com/kenkenpa198/modane-live2d-widget): トップページ下部の Live2D ウィジェット
+- [kem198/kems-clew.net](https://github.com/kem198/kems-clew.net): 当サイトのソースコード
+- [kem198/modane-live2d-widget](https://github.com/kem198/modane-live2d-widget): トップページ下部の Live2D ウィジェット
 
 ## 免責事項
 
@@ -26,7 +26,7 @@ permalink: /about/
 当サイトで掲載している画像や文章を含むコンテンツは無断転載することを禁止します。
 
 なお当サイトではファンアート及び二次創作物を多く扱います。  
-これらの制作物の著作権に関しては作者である kenkenpa198 と版権元の企業両者に帰属します。
+これらの制作物の著作権に関しては作者である KeM198 と版権元の企業両者に帰属します。
 
 参考文献:
 
@@ -77,5 +77,5 @@ permalink: /about/
 
 下記へ掲載しています。
 
-- [kenkenpa198/kems-clew > 5.権利表記](https://github.com/kenkenpa198/kems-clew#5-%E6%A8%A9%E5%88%A9%E8%A1%A8%E8%A8%98)
-- [kenkenpa198/modane-live2d-widget > 1. Live2D Cubism SDK for Web について](https://github.com/kem198/modane-live2d-widget?tab=readme-ov-file#1-live2d-cubism-sdk-for-web-%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
+- [kem198/kems-clew > 5.権利表記](https://github.com/kem198/kems-clew#5-%E6%A8%A9%E5%88%A9%E8%A1%A8%E8%A8%98)
+- [kem198/modane-live2d-widget > 1. Live2D Cubism SDK for Web について](https://github.com/kem198/modane-live2d-widget?tab=readme-ov-file#1-live2d-cubism-sdk-for-web-%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)


### PR DESCRIPTION
This pull request updates all references from the old username `kenkenpa198` to the new username `kem198` throughout the codebase and documentation. The changes ensure consistency in links, attributions, and configuration, reflecting the new GitHub account and branding.

**Repository and username updates:**

* Updated all GitHub repository links and references from `kenkenpa198` to `kem198` in documentation, markdown files, and posts, including `README.md`, multiple entries in `_posts`, and the `about.md` page. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R219) [[2]](diffhunk://#diff-4880bc27ed0bef29e60cc98da6b0bb4f3bbb9dd69f75c66b26a0ecba149e6857L16-R16) [[3]](diffhunk://#diff-c6c22fceae8eda9ca17afabcbdab533ed649e54498a440825928e58ed28fb183L14-R14) [[4]](diffhunk://#diff-f0ee06eb39e8dccb0a623975a84958003a1855c1a6fc66b1e3dbe9379432fbb2L14-R14) [[5]](diffhunk://#diff-cf8f8cc0a6ec47d672fc1a7312c3dfdb1d5bda74fc251a3606388282aeeb1e8bL15-R15) [[6]](diffhunk://#diff-cb00dc8f3dd03ae7b457150680b0dee7d27c9944468833bedbe01e28f001d67aL17-R17) [[7]](diffhunk://#diff-cb00dc8f3dd03ae7b457150680b0dee7d27c9944468833bedbe01e28f001d67aL43-R43) [[8]](diffhunk://#diff-cb00dc8f3dd03ae7b457150680b0dee7d27c9944468833bedbe01e28f001d67aL121-R121) [[9]](diffhunk://#diff-049d400b4837940fc4fd4519150b7867f092f8569718b4dfedb356713a29d3a2L9-R14) [[10]](diffhunk://#diff-049d400b4837940fc4fd4519150b7867f092f8569718b4dfedb356713a29d3a2L80-R81)
* Changed the `github_username` field in `_config.yml` to `kem198`.
* Updated footer social link to point to the new GitHub profile.

**Content and attribution updates:**

* Replaced author attribution from `kenkenpa198` to `kem198` in posts, commit logs, and user references. [[1]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL415-R415) [[2]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL591-R592) [[3]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL623-R635) [[4]](diffhunk://#diff-049d400b4837940fc4fd4519150b7867f092f8569718b4dfedb356713a29d3a2L9-R14) [[5]](diffhunk://#diff-049d400b4837940fc4fd4519150b7867f092f8569718b4dfedb356713a29d3a2L29-R29)
* Updated registered user and other identity references in code snippets and examples.

**Code and formatting improvements:**

* Minor formatting fix in `_config.yml` for YAML array indentation.
* Adjusted markdown formatting for emphasis and code examples in posts. [[1]](diffhunk://#diff-c90f2e76a20852858926a959f7d9fb049dc96177ba1ffa7324b5d60bfc966c20L93-R97) [[2]](diffhunk://#diff-c90f2e76a20852858926a959f7d9fb049dc96177ba1ffa7324b5d60bfc966c20L295-R291) [[3]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL214-R214) [[4]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL536-R542) [[5]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL554-R555) [[6]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL1208-R1208) [[7]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL1330-R1330)

**Metadata updates:**

* Updated `lastmod` dates in post front matter where appropriate. [[1]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL18-R18) [[2]](diffhunk://#diff-508f773f65e1eae72fbfcbaa63867f099ffb213f671279526d68085a642eebfaL214-R214)

These changes collectively ensure the site and documentation correctly reflect the new username and repository ownership, improving consistency and maintainability.